### PR TITLE
fix: remove LinearProgressIndicator to avoid jitter in server config page

### DIFF
--- a/lib/core/providers/server_config_provider.dart
+++ b/lib/core/providers/server_config_provider.dart
@@ -20,7 +20,6 @@ class ServerConfigProvider extends ChangeNotifier {
 
   bool _hasCompletedInitialLoad = false;
   bool _isLoading = false;
-  bool _isSaving = false;
   String? _statusMessage;
 
   ServerListenMode _listenMode = ServerListenMode.localhost;
@@ -37,7 +36,6 @@ class ServerConfigProvider extends ChangeNotifier {
 
   bool get hasCompletedInitialLoad => _hasCompletedInitialLoad;
   bool get isLoading => _isLoading;
-  bool get isSaving => _isSaving;
   String? get statusMessage => _statusMessage;
 
   ServerListenMode get listenMode => _listenMode;
@@ -246,7 +244,6 @@ class ServerConfigProvider extends ChangeNotifier {
   }
 
   Future<void> _runSave(Future<void> Function() operation) async {
-    _isSaving = true;
     _statusMessage = '正在保存配置...';
     notifyListeners();
 
@@ -256,7 +253,6 @@ class ServerConfigProvider extends ChangeNotifier {
     } catch (error) {
       _statusMessage = '保存失败: $error';
     } finally {
-      _isSaving = false;
       notifyListeners();
     }
   }

--- a/lib/features/server/pages/server_config_page.dart
+++ b/lib/features/server/pages/server_config_page.dart
@@ -70,8 +70,6 @@ class _ServerConfigViewState extends State<_ServerConfigView> {
               ? const Center(child: CircularProgressIndicator())
               : Column(
                   children: [
-                    if (provider.isSaving)
-                      const LinearProgressIndicator(minHeight: 2),
                     Expanded(
                       child: ListView(
                         padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
@@ -252,7 +250,7 @@ class _ServerConfigViewState extends State<_ServerConfigView> {
                               title: Text(l10n.serverConfigResetTitle),
                               subtitle: Text(l10n.serverConfigResetSubtitle),
                               trailing: const Icon(Icons.chevron_right),
-                              onTap: provider.isLoading || provider.isSaving
+                              onTap: provider.isLoading
                                   ? null
                                   : () => _confirmResetToDefaults(context),
                             ),


### PR DESCRIPTION
this pr remove the LinearProgressIndicator to avoid jitter in server config page
fix: #6 